### PR TITLE
feat(deps): Reset version number for lbt-grasshopper release

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ dragonfly Python packages:
 
 ## All Ladybug and Honeybee Packages Are Also Included
 
-Since dragonfly uses ladybug and honeybee, the following is also included:
+Since dragonfly uses ladybug and honeybee, the following dependencies are also included:
 
 * [lbt-ladybug](https://github.com/ladybug-tools/lbt-ladybug)
 * [lbt-honeybee](https://github.com/ladybug-tools/lbt-honeybee)


### PR DESCRIPTION
This isn't required but I think it will be nice to reset the patch version number at a milestone like the release of the grasshopper plugin.