### PR TITLE
fix(deps): Remove unused dragonfly-doe2

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ dragonfly Python packages:
 * [dragonfly-energy](https://github.com/ladybug-tools/dragonfly-energy)
 * [dragonfly-radiance](https://github.com/ladybug-tools/dragonfly-radiance)
 * [dragonfly-uwg](https://github.com/ladybug-tools/dragonfly-uwg)
-* [dragonfly-doe2](https://github.com/ladybug-tools/dragonfly-doe2)
 
 ## Included Dragonfly Core Libraries
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 dragonfly-energy==1.25.22
 dragonfly-radiance==0.3.12
 dragonfly-uwg==0.5.449
-dragonfly-doe2==0.11.3
 lbt-honeybee==0.8.167


### PR DESCRIPTION
Given that we are not using this package anymore, it should be removed.